### PR TITLE
Potential fix for code scanning alert no. 4: Potentially overflowing call to snprintf

### DIFF
--- a/server/src/charset.c
+++ b/server/src/charset.c
@@ -106,12 +106,22 @@ void loci_charset_send_request(proxy_conn_t *pc) {
 
 	*b++ = CHARSET_REQUEST;
 	/* add the preferred charset first. */
-	b += g_snprintf(b,eob-b," %s",charset);
+	int n = g_snprintf(b, eob - b, " %s", charset);
+	if (n < 0 || n >= eob - b) {
+		locid_debug(DEBUG_TELNET, pc, "Buffer overflow prevented while adding preferred charset.");
+		return;
+	}
+	b += n;
 
-	for(int i=0;charset_supported[i]!=NULL;i++) {
+	for (int i = 0; charset_supported[i] != NULL; i++) {
 		/* add the supported charsets next. */
-		if(strcmp(charset,charset_supported[i])) {
-			b += g_snprintf(b,eob-b," %s",charset_supported[i]);
+		if (strcmp(charset, charset_supported[i])) {
+			n = g_snprintf(b, eob - b, " %s", charset_supported[i]);
+			if (n < 0 || n >= eob - b) {
+				locid_debug(DEBUG_TELNET, pc, "Buffer overflow prevented while adding supported charset.");
+				return;
+			}
+			b += n;
 		}
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/luciensadi/lociterm/security/code-scanning/4](https://github.com/luciensadi/lociterm/security/code-scanning/4)

To fix the issue, we need to validate the return value of `g_snprintf` after each call. If the return value is negative or exceeds the remaining buffer size, we should stop further writes to the buffer to prevent overflow. This involves:
1. Capturing the return value of `g_snprintf` in a variable.
2. Checking if the return value is negative or greater than or equal to the remaining buffer size (`eob - b`).
3. Breaking out of the loop or function if the buffer is full or an error occurs.

The changes will be made in the `loci_charset_send_request` function, specifically around the calls to `g_snprintf` on lines 109 and 114.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
