### PR TITLE
Potential fix for code scanning alert no. 3: Wrong type of arguments to formatting function

### DIFF
--- a/server/src/debug.c
+++ b/server/src/debug.c
@@ -103,7 +103,7 @@ void locid_log(char *str, ...)
 }
 
 int locid_ssl_err_cb(const char *str, size_t len, void *u) {
-	locid_log("%s: %.*s",(char *)u,len-1,str);
+	locid_log("%s: %.*s", (char *)u, (int)(len-1), str);
 	return(0);
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/luciensadi/lociterm/security/code-scanning/3](https://github.com/luciensadi/lociterm/security/code-scanning/3)

To fix the issue, the `size_t` type of `len` should be explicitly cast to `int` before being passed to the `%.*s` format specifier. This ensures that the argument matches the expected type for the format specifier. The cast is safe as long as the value of `len` is within the range of an `int`. If there is a possibility that `len` could exceed the range of an `int`, additional checks should be added to handle such cases.

The specific change involves modifying the call to `locid_log` on line 106 to cast `len-1` to `int`. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
